### PR TITLE
Bug 1470263 - create json schema for manifest.json

### DIFF
--- a/schemas/manifest.yml
+++ b/schemas/manifest.yml
@@ -1,0 +1,81 @@
+$schema: http://json-schema.org/draft-06/schema#
+title: "Taskcluster Service Manifest"
+description: |-
+  Manifest of taskcluster service definitions available in a taskcluster service deployment.
+  These manifests are served from `$ROOT_URL/references/manifest.json`.
+
+  See https://github.com/taskcluster/taskcluster-references for further information.
+type: object
+properties:
+  services:
+    title: "List of taskcluster services"
+    description: |-
+      List of services that comprise a taskcluster build.
+    type: array
+    default: []
+    items:
+      title: "Service"
+      description: |-
+        A taskcluster service that exposes an HTTP/AMQP API.
+      type: object
+      properties:
+        serviceName:
+          title: Service Name
+          description: A short name for the service, such as `queue` / `purge-cache` / `ec2-manager`.
+          type: string
+          # let's keep this super simple.
+          pattern: ^[a-z][a-z0-9\-]*$
+        apis:
+          title: HTTP APIs
+          description: HTTP API exposed by this service.
+          type: array
+          default: []
+          items:
+            title: "HTTP API"
+            description: |-
+              HTTP API
+            type: object
+            properties:
+              version:
+                title: Version
+                description: Version of API, e.g. `v1`.
+                type: string
+                pattern: ^v[0-9][0-9\.\-]*$
+              reference:
+                title: HTTP API definition
+                description: A schema conformant to `$ROOT_URL/references/http.json` describing HTTP API exposed by service.
+                type: string
+            additionalProperties: false
+            required:
+              - version
+              - reference
+        pulse:
+          title: AMQP APIs
+          description: AMQP 0.9 API exposed by this service.
+          type: array
+          default: []
+          items:
+            title: "AMQP API"
+            description: |-
+              AMQP API
+            type: object
+            properties:
+              version:
+                title:
+                description: Version of API, e.g. `v1`.
+                type: string
+                pattern: ^v[0-9][0-9\.\-]*$
+              reference:
+                title: AMQP API definition
+                description: A schema conformant to `$ROOT_URL/references/pulse.json` describing AMQP API exposed by service.
+                type: string
+            additionalProperties: false
+            required:
+              - version
+              - reference
+      additionalProperties: false
+      required:
+        - serviceName
+additionalProperties: false
+required:
+  - services


### PR DESCRIPTION
For now just creating schema, we can create other PRs/bugs for documenting its existence, and using it at runtime to validate generated `manifest.json`.

See [bug 1470263](https://bugzil.la/1470263).